### PR TITLE
Add dev as a tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "laravel",
         "flare",
         "errors",
-        "laravel-error-share"
+        "laravel-error-share",
+        "dev"
     ],
     "homepage": "https://github.com/spatie/laravel-error-share",
     "license": "MIT",


### PR DESCRIPTION
This makes composer suggest it as a "--dev" dependency when requiring it without the "--dev" flag.