### PR TITLE
Add new Copy as Markdown button

### DIFF
--- a/resources/views/components/navigation.blade.php
+++ b/resources/views/components/navigation.blade.php
@@ -21,6 +21,11 @@
             </div>
 
             <div class="flex items-center gap-3 sm:gap-6">
+                @includeWhen(
+                    view()->exists('laravel-exceptions-renderer::components.copy-button'),
+                    'laravel-exceptions-renderer::components.copy-button',
+                    ['markdown' => $exceptionAsMarkdown]
+                )
                 <x-laravel-exceptions-renderer::error-share :exception="$exception" />
                 <x-laravel-exceptions-renderer::theme-switcher />
             </div>


### PR DESCRIPTION
With Laravel 12.25 we got the new "Copy as Markdown" button in the exception page: https://github.com/laravel/framework/pull/56657

This change includes this button but only if the component exists, making it fail safe for <12.25 laravel versions.