### PR TITLE
Fix error Undefined variable $exceptionAsMarkdown

### DIFF
--- a/resources/views/components/navigation.blade.php
+++ b/resources/views/components/navigation.blade.php
@@ -21,11 +21,12 @@
             </div>
 
             <div class="flex items-center gap-3 sm:gap-6">
-                @includeWhen(
-                    view()->exists('laravel-exceptions-renderer::components.copy-button'),
-                    'laravel-exceptions-renderer::components.copy-button',
-                    ['markdown' => $exceptionAsMarkdown]
-                )
+                @if (view()->exists('laravel-exceptions-renderer::components.copy-button'))
+                    @include(
+                        'laravel-exceptions-renderer::components.copy-button',
+                        ['markdown' => $exceptionAsMarkdown]
+                    )
+                @endif
                 <x-laravel-exceptions-renderer::error-share :exception="$exception" />
                 <x-laravel-exceptions-renderer::theme-switcher />
             </div>


### PR DESCRIPTION
This pull request makes a small change to the way the copy button component is conditionally included in the navigation view. Instead of using `@includeWhen`, it now uses an `@if` statement to check if the view exists before including it.

Fixes https://github.com/spatie/laravel-error-share/issues/11