### PR TITLE
Fix failing view compilation in Laravel > 12.29

### DIFF
--- a/resources/views/components/navigation.blade.php
+++ b/resources/views/components/navigation.blade.php
@@ -28,7 +28,9 @@
                     )
                 @endif
                 <x-laravel-exceptions-renderer::error-share :exception="$exception" />
-                <x-laravel-exceptions-renderer::theme-switcher />
+                @if (view()->exists('laravel-exceptions-renderer::theme-switcher'))
+                    <x-dynamic-component name="laravel-exceptions-renderer::theme-switcher" />
+                @endif
             </div>
         </div>
     </div>


### PR DESCRIPTION
Resolves https://github.com/spatie/laravel-error-share/issues/14. 

This PR doesn't make the share button functional in Laravel > 12.29. 
But this allows the user to install the `laravel-flare` package, without having exceptions when trying to run `php artisan optimize`  
